### PR TITLE
Make module args explicit, add systemPackages example

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
       system = "x86_64-linux";
       specialArgs = attrs;
       modules = [
-        ({modulesPath, ... }: {
+        ({modulesPath, config, lib, pkgs, ... }: {
           imports = [
             (modulesPath + "/installer/scan/not-detected.nix")
             (modulesPath + "/profiles/qemu-guest.nix")
@@ -28,6 +28,11 @@
             # change this to your ssh key
             "CHANGE"
           ];
+         
+          environment.systemPackages = map lib.lowPrio [
+            pkgs.curl
+            pkgs.gitMinimal
+          ];  
         })
       ];
     };


### PR DESCRIPTION
Hello,

After discussion in https://github.com/numtide/nixos-anywhere/issues/202 i thought it might be less confusing for new users if we keep module arguments explicit and include an example on how to add extra packages to the installed system.